### PR TITLE
Fix Android NDK unsupported ABIs

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -10,10 +10,6 @@ elseif( ARCH_DIR STREQUAL "x86" )
   set( ARCH_DIR "i686" )
 elseif( ARCH_DIR STREQUAL "x86_64" )
   set( ARCH_DIR "westmere" )
-elseif( ARCH_DIR STREQUAL "mips" )
-  set( ARCH_DIR "mips32" )
-elseif( ARCH_DIR STREQUAL "mips64" )
-  set( ARCH_DIR "mips64r6" )
 endif()
 
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ android {
             }
         }
         ndk {
-            abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a', 'mips', 'mips64'
+            abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
         }
     }
     buildTypes {

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ tar -xzf $srcfile
 cd $srcdir
 
 targetPlatforms="$@"
-[ "$targetPlatforms" ] || targetPlatforms="arm mips x86 ios"
+[ "$targetPlatforms" ] || targetPlatforms="arm x86 ios"
 
 for targetPlatform in $targetPlatforms
 do
@@ -39,10 +39,6 @@ do
       dist-build/android-arm.sh
       dist-build/android-armv7-a.sh
       dist-build/android-armv8-a.sh
-      ;;
-    "mips")
-      dist-build/android-mips32.sh
-      dist-build/android-mips64.sh
       ;;
     "x86")
       dist-build/android-x86.sh


### PR DESCRIPTION
- Android builds are failing with the following error:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':react-native-sodium'.
> ABIs [mips64, armeabi, mips] are not supported for platform. Supported ABIs are [armeabi-v7a, arm64-v8a, x86, x86_64].
```

- This is caused by a recent update to the Android NDK to r17 which removes support for several ABIs https://github.com/android-ndk/ndk/wiki/Changelog-r17:

> Support for ARMv5 (armeabi), MIPS, and MIPS64 has been removed. Attempting to build any of these ABIs will result in an error.

- This removes the unsupported ABIs from the `abiFilters` and the build and CMAKE scripts.