### PR TITLE
Fix compatibility with Android Gradle Plugin 4.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,11 +39,6 @@ android {
             path "CMakeLists.txt"
         }
     }
-    sourceSets {
-        main {
-            jniLibs.srcDirs = ['./lib']
-        }
-    }
 }
 
 dependencies {


### PR DESCRIPTION
With Android Gradle Plugin 4.0, cmake libs are now automatically bundled:
https://developer.android.com/studio/projects/gradle-external-native-builds#jniLibs

This means that manually adding the built libs to `jniLibs`, as is being done in the `build.gradle` file, results in a duplicate symbol error as multiple `libsodium.so` are present.

Note: This is a breaking change on AGP < 4.0 so this PR is targeting a `compat` branch until https://github.com/curoo/expend-mobile-app uses AGP 4 on its `master` branch.